### PR TITLE
Missing export `toggleStringInArray`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 # Ignore development tools and configuration files
+src/
 
 node_modules/
 .git/

--- a/.release/release-notes.txt
+++ b/.release/release-notes.txt
@@ -1,5 +1,2 @@
 ## Changes
-- Folder structure changed and types removed from package.json
-- changed export pattern
-- @types dir for decleration file
-- documented the types guidence
+- added a missing export `toggleStringInArray`

--- a/package.json
+++ b/package.json
@@ -255,6 +255,14 @@
       },
       "import": "./lib/esm/validateObjectsForKey/index.js",
       "require": "./lib/cjs/validateObjectsForKey/index.js"
+    },
+    "./toggleStringInArray": {
+      "types": {
+        "require": "./@types/toggleStringInArray/index.d.ts",
+        "default": "./@types/toggleStringInArray/index.d.ts"
+      },
+      "import": "./lib/esm/toggleStringInArray/index.js",
+      "require": "./lib/cjs/toggleStringInArray/index.js"
     }
     
   },


### PR DESCRIPTION
# What does this PR do?
- fixes the missing export of `toggleStringInArray` file in package json
